### PR TITLE
bugfix/team name with spaces breaking emails

### DIFF
--- a/backend/graphql/resolvers/MsgComment.js
+++ b/backend/graphql/resolvers/MsgComment.js
@@ -35,7 +35,7 @@ const msgCommentResolvers = {
 						(await sgMail.send({
 							// notifies subscribed users of the new comment
 							to: emails,
-							from: `${message.team.name}@team.home`,
+							from: `${message.team.name.split(' ').join('')}@team.home`,
 							subject: `The message ${
 								message.title
 							} has a new comment from ${firstName} ${lastName} on your team ${

--- a/backend/graphql/resolvers/Team.js
+++ b/backend/graphql/resolvers/Team.js
@@ -94,11 +94,11 @@ const teamResolvers = {
 								}));
 								email &&
 									sgMail.send({
-										// notifies subscribed users of the new comment
+										// notifies invited user
 										to: email,
-										from: `${team.name}@team.home`,
-										subject: `You been invited to ${team.name}`,
-										text: `You been invited to ${
+										from: `${team.name.split(' ').join('')}@team.home`,
+										subject: `You have been been invited to ${team.name}`,
+										text: `You have been invited to ${
 											team.name
 										} by ${firstName} ${lastName}`,
 										html: /* HTML */ `


### PR DESCRIPTION
# Description

Fix bug where if a team name had spaces emails wouldn't be sent because the sender address was invalid.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Change status
- [x] Complete, tested, ready to review and merge


# How Has This Been Tested?
React dev environment

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
