### PR TITLE
Remove global css selector for 100% width

### DIFF
--- a/frontend/src/LandingView/styles/SignInSignUpStyled.js
+++ b/frontend/src/LandingView/styles/SignInSignUpStyled.js
@@ -17,6 +17,7 @@ const StyledSignInUp = styled.div`
 	flex-flow: row;
 	z-index: 1000;
 	justify-content: space-between;
+	width: 100%;
 	&:hover {
 		background-color: #17151b;
 	}

--- a/frontend/src/Nav/styles/index.js
+++ b/frontend/src/Nav/styles/index.js
@@ -30,6 +30,7 @@ const TextIMG = styled.img`
 const NavBar = styled.div`
 	background: linear-gradient(100deg, #17151b, rgba(222, 59, 97, 0.6), #17151b);
 	background-size: 600% 600%;
+	width: 100%;
 	position: fixed;
 	left: 0px;
 	top: 0px;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -5,7 +5,6 @@
 
 #root {
 	max-width: 1200px;
-	width: 100%;
 	margin: 0 auto;
 }
 


### PR DESCRIPTION
# Description

Remove global css selector for 100% width that was breaking everything

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

React dev environment.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
