### PR TITLE
Fix bug with adding messages

### DIFF
--- a/frontend/src/MessageBoard/components/MessageBoard.js
+++ b/frontend/src/MessageBoard/components/MessageBoard.js
@@ -243,7 +243,7 @@ class MessageBoard extends React.Component {
 						<AddMessage
 							closeHandler={this.closeModalHandler}
 							stopProp={this.stopProp}
-							team={this.props.team}
+							team={this.props.team._id}
 							user={this.props.currentUser._id}
 						/>
 					) : null}


### PR DESCRIPTION
# Description

When specifying which team to add the message to, the entire team object was being sent to the server when it should have only been the team _id

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

React dev environment.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
