### PR TITLE
Removed stripe secret key info from frontend readme

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -7,7 +7,7 @@
 1. Fork and Clone the `labs9-team-home` repo,
 2. `cd` into the frontend folder of the cloned repo,
 3. In your commandline-tool, run `yarn install` to install packages,
-4. Create an `.env` file and create the variables `REACT_APP_AUTH0_DOMAIN`, `REACT_APP_AUTH0_CLIENT_ID`, `REACT_APP_UPLOAD_PRESET`, `REACT_APP_API_KEY`, `REACT_APP_API_SECRET`, `REACT_APP_CLOUD_NAME`, `STRIPE_PUBLISHABLE_KEY` and `STRIPE_SECRET_KEY`. Instructions below on how to get the key for each variable.
+4. Create an `.env` file and create the variables `REACT_APP_AUTH0_DOMAIN`, `REACT_APP_AUTH0_CLIENT_ID`, `REACT_APP_UPLOAD_PRESET`, `REACT_APP_API_KEY`, `REACT_APP_API_SECRET`, `REACT_APP_CLOUD_NAME`, and `STRIPE_PUBLISHABLE_KEY`. Instructions below on how to get the key for each variable.
 5. In your commandline-tool, run `yarn start`,
 6. The app will open on `localhost:3000`.
 
@@ -44,8 +44,7 @@
 1. [Create an account](https://stripe.com/)
 2. Select the developer option.
 3. Click `Get your API keys`
-4. Copy `Publishable key` and `Secret key` to their respective variables.
-5. The publishable key is used in development and the secret key is used in production.
+4. Copy `Publishable key` its respective variable.
 
 ## File structure
 


### PR DESCRIPTION
# Description

removed stripe secret key part of frontend README.md

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Change status
- [x] Complete, tested, ready to review and merge
- [ ] Complete, but not tested (may need new tests)
- [ ] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
