### PR TITLE
Add paywall to invite form

### DIFF
--- a/frontend/src/MessageBoard/components/Invites.js
+++ b/frontend/src/MessageBoard/components/Invites.js
@@ -7,6 +7,7 @@ import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import { colors } from '../../colorVariables';
+import { Link } from 'react-router-dom';
 
 const { button } = colors;
 
@@ -37,12 +38,31 @@ const Overlay = styled(DialogContent)`
 
 const SubmitButton = styled(Button)`
 	color: #fff;
+	${({ pro }) =>
+		pro &&
+		/* CSS */ `
+		margin: 0 auto;
+		width: 200px;
+		height: 40px;
+	`}
 `;
 
 const Title = styled(DialogTitle)`
 	background-color: ${button};
 	h2 {
 		color: #fff;
+	}
+`;
+
+const Paywall = styled.div`
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+`;
+
+const GoPro = styled(Link)`
+	&:hover {
+		text-decoration: none;
 	}
 `;
 
@@ -76,43 +96,68 @@ export default function Invites({
 	email,
 	changeHandler,
 	closeHandler,
-	submitHandler
+	submitHandler,
+	team,
+	currentUser
 }) {
 	return (
 		<Container open={open} onClose={closeHandler}>
 			<Overlay>
-				<Title id="form-dialog-title" style={{ color: '#fff' }}>
-					Invite User
-				</Title>
-				<form onSubmit={submitHandler} style={{ color: '#fff' }}>
-					<label htmlFor="email" />
-					<TextField
-						id="outlined-bare"
-						type="email"
-						name="email"
-						variant="outlined"
-						placeholder="email"
-						onChange={changeHandler}
-						value={email}
-						fullWidth
-					/>
-					<label htmlFor="phone number" />
-					<TextField
-						placeholder="phone number"
-						type="text"
-						name="number"
-						variant="outlined"
-						onChange={changeHandler}
-						value={number}
-						fullWidth
-					/>
-					<DialogActions>
-						<SubmitButton type="submit">Submit</SubmitButton>
-						<Button color="secondary" onClick={closeHandler}>
-							Cancel
-						</Button>
-					</DialogActions>
-				</form>
+				{team.users.length < 5 || team.premium ? (
+					<>
+						<Title id="form-dialog-title" style={{ color: '#fff' }}>
+							Invite User
+						</Title>
+						<form onSubmit={submitHandler} style={{ color: '#fff' }}>
+							<label htmlFor="email" />
+							<TextField
+								id="outlined-bare"
+								type="email"
+								name="email"
+								variant="outlined"
+								placeholder="email"
+								onChange={changeHandler}
+								value={email}
+								fullWidth
+							/>
+							<label htmlFor="phone number" />
+							<TextField
+								placeholder="phone number"
+								type="text"
+								name="number"
+								variant="outlined"
+								onChange={changeHandler}
+								value={number}
+								fullWidth
+							/>
+							<DialogActions>
+								<SubmitButton type="submit">Submit</SubmitButton>
+								<Button color="secondary" onClick={closeHandler}>
+									Cancel
+								</Button>
+							</DialogActions>
+						</form>
+					</>
+				) : (
+					<Paywall>
+						<Title>Sorry, free teams can only have up to 5 users.</Title>
+						{team.users.find(({ user }) => user._id === currentUser._id)
+							.admin ? (
+							<GoPro to="/settings">
+								<SubmitButton
+									pro
+									size="large"
+									variant="contained"
+									color="secondary"
+								>
+									Go Pro
+								</SubmitButton>
+							</GoPro>
+						) : (
+							<Title>Tell your team administrators to upgrade.</Title>
+						)}
+					</Paywall>
+				)}
 			</Overlay>
 		</Container>
 	);

--- a/frontend/src/MessageBoard/components/MessageBoard.js
+++ b/frontend/src/MessageBoard/components/MessageBoard.js
@@ -249,6 +249,8 @@ class MessageBoard extends React.Component {
 					<Mutation mutation={mutation.INVITE_USER}>
 						{inviteUser => (
 							<Invites
+								currentUser={this.props.currentUser}
+								team={this.props.team}
 								open={this.state.showInvite}
 								closeHandler={this.closeInviteHandler}
 								stopProp={this.stopProp}


### PR DESCRIPTION
# Description

- When a user is on a free team with more than 4 users and they click the invite button, they will be prompted with a message telling them that free teams can only have up to 5 users and, if they are an admin, a link to the settings page to upgrade or a message instructing the user to the tell the team administrators to upgrade.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?

React dev environment.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My code has been reviewed by at least one peer
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts
